### PR TITLE
Optimise planet rendering

### DIFF
--- a/src/lib/planet.c
+++ b/src/lib/planet.c
@@ -364,8 +364,14 @@ static void planet_update_render_flat(struct planet_internals *p,
 	const uint32_t *restrict texture_row_offset_t = p->texture;
 	const uint32_t *restrict texture_row_offset_b = p->texture +
 			(p->texture_h - 1) * p->texture_r;
-	int angle, rot;
 	const int *restrict angle_cache = p->angles;
+	int angle, rot, rot2;
+
+	rot = rotation;
+	rot2 = rotation + FIX_MULTIPLE;
+	if (rot2 >= FIX_MULTIPLE * 5 / 2) {
+		rot2 -= 2 << FIX_SHIFT;
+	}
 
 	/* Loop through top left quarter of circle, and render symmetrically
 	 * reflected points on each iteration. */
@@ -398,12 +404,9 @@ static void planet_update_render_flat(struct planet_internals *p,
 			/* Apply planet's current rotation (between 0 and 2) to
 			 * angle (which is between 0 and 0.5), and wrap back to
 			 * range 0 to 2 */
-			rot = angle - rotation;
-			if (rot < 0)
-				rot += (2 << FIX_SHIFT);
 
 			/* Get offset into texture, for current angle. */
-			offset = (p->texture_w2 * rot) >> FIX_SHIFT;
+			offset = (p->texture_w2 * (rot + angle)) >> FIX_SHIFT;
 
 			/* Set pixel colour from texture, for top and bottom
 			 * rows */
@@ -416,11 +419,8 @@ static void planet_update_render_flat(struct planet_internals *p,
 			/* Angle from other half can be reused as (1 - angle),
 			 * exploiting cosine symmetry.  (To map from first
 			 * quadrant to second quadrant.) */
-			angle = FIX_MULTIPLE - angle - rotation;
-			if (angle < 0)
-				angle += (2 << FIX_SHIFT);
 
-			offset = (p->texture_w2 * angle) >> FIX_SHIFT;
+			offset = (p->texture_w2 * (rot2 - angle)) >> FIX_SHIFT;
 
 			/* Get offset to pixels on right hand side of circle */
 			right = diameter - x;
@@ -481,9 +481,15 @@ static void planet_update_render_lighting(struct planet_internals *p,
 	const uint32_t *restrict texture_row_offset_t = p->texture;
 	const uint32_t *restrict texture_row_offset_b = p->texture +
 			(p->texture_h - 1) * p->texture_r;
-	int angle, rot;
 	const int *restrict angle_cache = p->angles;
 	const Uint8 *restrict l = p->lighting; /* lighting cache index */
+	int angle, rot, rot2;
+
+	rot = rotation;
+	rot2 = rotation + FIX_MULTIPLE;
+	if (rot2 >= FIX_MULTIPLE * 5 / 2) {
+		rot2 -= 2 << FIX_SHIFT;
+	}
 
 	/* Loop through top left quarter of circle, and render symmetrically
 	 * reflected points on each iteration. */
@@ -516,12 +522,9 @@ static void planet_update_render_lighting(struct planet_internals *p,
 			/* Apply planet's current rotation (between 0 and 2) to
 			 * angle (which is between 0 and 0.5), and wrap back to
 			 * range 0 to 2 */
-			rot = angle - rotation;
-			if (rot < 0)
-				rot += (2 << FIX_SHIFT);
 
 			/* Get offset into texture, for current angle. */
-			offset = (p->texture_w2 * rot) >> FIX_SHIFT;
+			offset = (p->texture_w2 * (rot + angle)) >> FIX_SHIFT;
 
 			/* Set pixel colour from texture, for top and bottom
 			 * rows */
@@ -536,11 +539,8 @@ static void planet_update_render_lighting(struct planet_internals *p,
 			/* Angle from other half can be reused as (1 - angle),
 			 * exploiting cosine symmetry.  (To map from first
 			 * quadrant to second quadrant.) */
-			angle = FIX_MULTIPLE - angle - rotation;
-			if (angle < 0)
-				angle += (2 << FIX_SHIFT);
 
-			offset = (p->texture_w2 * angle) >> FIX_SHIFT;
+			offset = (p->texture_w2 * (rot2 - angle)) >> FIX_SHIFT;
 
 			/* Get offset to pixels on right hand side of circle */
 			right = diameter - x;

--- a/src/lib/planet.c
+++ b/src/lib/planet.c
@@ -593,26 +593,26 @@ void planet_plot_texture_scaled(struct planet *p, SDL_Surface *screen,
  * value.  Call once per channel with appropriate mask.  marker indicates top
  * left pixel in grid, width is row span of large image. */
 static uint32_t planet_make_small_texture_px(const uint32_t *marker,
-		uint32_t mask, unsigned shift, int width)
+		uint32_t mask, unsigned shift, int span)
 {
 	uint32_t ret = 0;
-	width -= 4;
+	span -= 4;
 
 	ret += ((*marker++) & mask) >> shift;
 	ret += ((*marker++) & mask) >> shift;
 	ret += ((*marker++) & mask) >> shift;
 	ret += ((*marker++) & mask) >> shift;
-	marker += width;
+	marker += span;
 	ret += ((*marker++) & mask) >> shift;
 	ret += ((*marker++) & mask) >> shift;
 	ret += ((*marker++) & mask) >> shift;
 	ret += ((*marker++) & mask) >> shift;
-	marker += width;
+	marker += span;
 	ret += ((*marker++) & mask) >> shift;
 	ret += ((*marker++) & mask) >> shift;
 	ret += ((*marker++) & mask) >> shift;
 	ret += ((*marker++) & mask) >> shift;
-	marker += width;
+	marker += span;
 	ret += ((*marker++) & mask) >> shift;
 	ret += ((*marker++) & mask) >> shift;
 	ret += ((*marker++) & mask) >> shift;

--- a/src/lib/planet.c
+++ b/src/lib/planet.c
@@ -593,33 +593,33 @@ void planet_plot_texture_scaled(struct planet *p, SDL_Surface *screen,
  * value.  Call once per channel with appropriate mask.  marker indicates top
  * left pixel in grid, width is row span of large image. */
 static uint32_t planet_make_small_texture_px(const uint32_t *marker,
-		uint32_t mask, int width)
+		uint32_t mask, unsigned shift, int width)
 {
 	uint32_t ret = 0;
 	width -= 4;
 
-	ret += (*marker++) & mask;
-	ret += (*marker++) & mask;
-	ret += (*marker++) & mask;
-	ret += (*marker++) & mask;
+	ret += ((*marker++) & mask) >> shift;
+	ret += ((*marker++) & mask) >> shift;
+	ret += ((*marker++) & mask) >> shift;
+	ret += ((*marker++) & mask) >> shift;
 	marker += width;
-	ret += (*marker++) & mask;
-	ret += (*marker++) & mask;
-	ret += (*marker++) & mask;
-	ret += (*marker++) & mask;
+	ret += ((*marker++) & mask) >> shift;
+	ret += ((*marker++) & mask) >> shift;
+	ret += ((*marker++) & mask) >> shift;
+	ret += ((*marker++) & mask) >> shift;
 	marker += width;
-	ret += (*marker++) & mask;
-	ret += (*marker++) & mask;
-	ret += (*marker++) & mask;
-	ret += (*marker++) & mask;
+	ret += ((*marker++) & mask) >> shift;
+	ret += ((*marker++) & mask) >> shift;
+	ret += ((*marker++) & mask) >> shift;
+	ret += ((*marker++) & mask) >> shift;
 	marker += width;
-	ret += (*marker++) & mask;
-	ret += (*marker++) & mask;
-	ret += (*marker++) & mask;
-	ret += (*marker++) & mask;
+	ret += ((*marker++) & mask) >> shift;
+	ret += ((*marker++) & mask) >> shift;
+	ret += ((*marker++) & mask) >> shift;
+	ret += ((*marker++) & mask) >> shift;
 
 	ret /= 16;
-	return ret & mask;
+	return (ret << shift) & mask;
 }
 
 
@@ -634,10 +634,10 @@ static void planet_make_small_texture(struct planet *p)
 	for (y = 0; y < p->small.texture_h - 1; y++) {
 		for (x = 0; x < p->small.texture_w - 1; x++) {
 			small[i] = planet_make_small_texture_px(
-					&big[j], 0x00ff00ff,
+					&big[j], 0x00ff00ff, 0,
 					p->big.texture_w);
 			small[i] |= planet_make_small_texture_px(
-					&big[j], 0xff00ff00,
+					&big[j], 0xff00ff00, 8,
 					p->big.texture_w);
 			i++;
 			j += 4;

--- a/src/lib/planet.c
+++ b/src/lib/planet.c
@@ -626,6 +626,17 @@ static uint32_t planet_make_small_texture_px(const uint32_t *marker,
 	return (ret << shift) & mask;
 }
 
+static void planet__texture_extend(uint32_t *restrict texture,
+		int height, int row_span, int width)
+{
+	for (int y = 0; y < height; y++) {
+		int i = y * row_span;
+		for (int x = 0; x < row_span - width; x++) {
+			texture[i + width] = texture[i];
+			i++;
+		}
+	}
+}
 
 static void planet_make_small_texture(struct planet *p)
 {
@@ -655,6 +666,11 @@ static void planet_make_small_texture(struct planet *p)
 		small[i++] = big[j];
 		j += 4;
 	}
+
+	planet__texture_extend(p->small.texture,
+			p->small.texture_h,
+			p->small.texture_r,
+			p->small.texture_w);
 }
 
 
@@ -694,6 +710,11 @@ bool planet_get_texture_from_file(struct planet *planet, const char *filename,
 	}
 
 	SDL_FreeSurface(sdl_texture);
+
+	planet__texture_extend(p->texture,
+			p->texture_h,
+			p->texture_r,
+			p->texture_w);
 
 	planet_make_small_texture(planet);
 
@@ -842,6 +863,11 @@ bool planet_generate_texture(struct planet *planet,
 
 	free(sine);
 
+	planet__texture_extend(p->texture,
+			p->texture_h,
+			p->texture_r,
+			p->texture_w);
+
 	colour_texture_to_screen(screen, texture,
 			p->texture_r * p->texture_h,
 			p->texture);
@@ -933,6 +959,11 @@ bool planet_generate_texture_man_made(struct planet *planet, struct colour c,
 
 	cellular_texture_free(cells);
 	free(sine);
+
+	planet__texture_extend(p->texture,
+			p->texture_h,
+			p->texture_r,
+			p->texture_w);
 
 	colour_texture_to_screen(screen, texture,
 			p->texture_r * p->texture_h,


### PR DESCRIPTION
Removes branches from inner loop of planet render by extending textures to
have an extra quarter width, and storing wrapped pixel values in the excess.